### PR TITLE
fix rake task, and update with new data from wikipedia

### DIFF
--- a/lib/iso_country_codes/iso_3166_1.rb
+++ b/lib/iso_country_codes/iso_3166_1.rb
@@ -310,7 +310,7 @@ class IsoCountryCodes
     end
     class COD < Code #:nodoc:
       self.numeric = %q{180}
-      self.name    = %q{Congo (Democratic Republic of the)}
+      self.name    = %q{Congo, Democratic Republic of the}
       self.alpha2  = %q{CD}
       self.alpha3  = %q{COD}
     end
@@ -421,6 +421,12 @@ class IsoCountryCodes
       self.name    = %q{Estonia}
       self.alpha2  = %q{EE}
       self.alpha3  = %q{EST}
+    end
+    class SWZ < Code #:nodoc:
+      self.numeric = %q{748}
+      self.name    = %q{Eswatini}
+      self.alpha2  = %q{SZ}
+      self.alpha3  = %q{SWZ}
     end
     class ETH < Code #:nodoc:
       self.numeric = %q{231}
@@ -712,7 +718,7 @@ class IsoCountryCodes
     end
     class KOR < Code #:nodoc:
       self.numeric = %q{410}
-      self.name    = %q{Korea (Republic of)}
+      self.name    = %q{Korea, Republic of}
       self.alpha2  = %q{KR}
       self.alpha3  = %q{KOR}
     end
@@ -787,12 +793,6 @@ class IsoCountryCodes
       self.name    = %q{Macao}
       self.alpha2  = %q{MO}
       self.alpha3  = %q{MAC}
-    end
-    class MKD < Code #:nodoc:
-      self.numeric = %q{807}
-      self.name    = %q{Macedonia (the former Yugoslav Republic of)}
-      self.alpha2  = %q{MK}
-      self.alpha3  = %q{MKD}
     end
     class MDG < Code #:nodoc:
       self.numeric = %q{450}
@@ -874,7 +874,7 @@ class IsoCountryCodes
     end
     class MDA < Code #:nodoc:
       self.numeric = %q{498}
-      self.name    = %q{Moldova (Republic of)}
+      self.name    = %q{Moldova, Republic of}
       self.alpha2  = %q{MD}
       self.alpha3  = %q{MDA}
     end
@@ -940,7 +940,7 @@ class IsoCountryCodes
     end
     class NLD < Code #:nodoc:
       self.numeric = %q{528}
-      self.name    = %q{Netherlands}
+      self.name    = %q{Netherlands, Kingdom of the}
       self.alpha2  = %q{NL}
       self.alpha3  = %q{NLD}
     end
@@ -985,6 +985,12 @@ class IsoCountryCodes
       self.name    = %q{Norfolk Island}
       self.alpha2  = %q{NF}
       self.alpha3  = %q{NFK}
+    end
+    class MKD < Code #:nodoc:
+      self.numeric = %q{807}
+      self.name    = %q{North Macedonia}
+      self.alpha2  = %q{MK}
+      self.alpha3  = %q{MKD}
     end
     class MNP < Code #:nodoc:
       self.numeric = %q{580}
@@ -1280,12 +1286,6 @@ class IsoCountryCodes
       self.alpha2  = %q{SJ}
       self.alpha3  = %q{SJM}
     end
-    class SWZ < Code #:nodoc:
-      self.numeric = %q{748}
-      self.name    = %q{Swaziland}
-      self.alpha2  = %q{SZ}
-      self.alpha3  = %q{SWZ}
-    end
     class SWE < Code #:nodoc:
       self.numeric = %q{752}
       self.name    = %q{Sweden}
@@ -1366,7 +1366,7 @@ class IsoCountryCodes
     end
     class TUR < Code #:nodoc:
       self.numeric = %q{792}
-      self.name    = %q{Turkey}
+      self.name    = %q{Türkiye}
       self.alpha2  = %q{TR}
       self.alpha3  = %q{TUR}
     end

--- a/rakelib/iso_3166_1.rb
+++ b/rakelib/iso_3166_1.rb
@@ -7,7 +7,7 @@ class IsoCountryCodes
   module Task
     module UpdateCodes
       def self.get
-        doc    = Nokogiri::HTML.parse(open('https://en.wikipedia.org/wiki/ISO_3166-1'), nil, 'UTF-8')
+        doc    = Nokogiri::HTML.parse(URI.open('https://en.wikipedia.org/wiki/ISO_3166-1'), nil, 'UTF-8')
         codes  = {}
         td_map = {
           :name    => 1,


### PR DESCRIPTION
Since Smarty uses 3-letter country codes, and Stripe uses 2-letter country codes, it seemed like a good idea to add a gem to handle the translation for us. The forked repo seems to do the trick, but needs to be updated with new data.


This PR updates the Rake task to work again, and runs the rake task to update with new data from Wikipedia
